### PR TITLE
fix: remove -draft suffix from v0.2 version strings and fix schema validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,8 +35,16 @@ jobs:
       - name: Validate v0.2 provenance examples against schema
         run: |
           node scripts/validate.js \
-            -s spec/schema/halos-provenance-v0.2-draft.schema.json \
-            examples/v0.2-graph.json
+            -s spec/schema/halos-provenance-v0.2.schema.json \
+            examples/v0.2-graph.json \
+            examples/education-student-learning.halos.json \
+            examples/enterprise-software-development.halos.json \
+            examples/government-policy-legal.halos.json \
+            examples/journalism-news-media.halos.json \
+            examples/music-creative-production.halos.json \
+            examples/nonprofit-humanitarian.halos.json \
+            examples/realtime-critical-systems.halos.json \
+            examples/scientific-research.halos.json
 
       - name: Validate manifest.json against schema
         run: node scripts/validate.js -s spec/schema/manifest.schema.json spec/manifest.json

--- a/examples/enterprise-software-development.halos.json
+++ b/examples/enterprise-software-development.halos.json
@@ -15,7 +15,7 @@
     {
       "model": "claude-sonnet-4-6",
       "provider": "Anthropic",
-      "role": "analysis",
+      "role": "assistance",
       "taskType": "comparing",
       "techniques": ["code-pattern-matching", "abstract-syntax-tree-analysis"],
       "description": "Compared three legacy reconciliation codebases to identify shared patterns, divergent behaviors, and undocumented business rules"
@@ -33,7 +33,7 @@
   "review": [
     {
       "reviewer": "Marcus Webb",
-      "type": "security-review",
+      "type": "other",
       "timestamp": "2026-03-25T16:00:00Z",
       "notes": "Security review passed: no raw card data stored, audit log is append-only with cryptographic chaining, all endpoints require mTLS with vertical-specific certificates"
     },

--- a/examples/government-policy-legal.halos.json
+++ b/examples/government-policy-legal.halos.json
@@ -15,7 +15,7 @@
     {
       "model": "polaris-research-v3",
       "provider": "Polaris Analytics",
-      "role": "analysis",
+      "role": "assistance",
       "description": "Synthesized findings from 23 published studies on rent stabilization; ran Monte Carlo simulations modeling housing supply impacts under three scenarios"
     },
     {
@@ -29,7 +29,7 @@
   "review": [
     {
       "reviewer": "David Oluwale",
-      "type": "editorial-review",
+      "type": "editorial",
       "timestamp": "2026-03-18T16:00:00Z",
       "notes": "Division director review; requested sensitivity analysis, strengthened limitations section, moved comparative table to appendix"
     },

--- a/examples/journalism-news-media.halos.json
+++ b/examples/journalism-news-media.halos.json
@@ -15,13 +15,13 @@
     {
       "model": "docparse-regulatory-v3",
       "provider": "DocParse AI",
-      "role": "analysis",
+      "role": "assistance",
       "description": "Analyzed 4,300 public regulatory filings to categorize violations, identify enforcement gaps, and generate timeline patterns"
     },
     {
       "model": "docparse-regulatory-v3",
       "provider": "DocParse AI",
-      "role": "analysis",
+      "role": "assistance",
       "description": "Cross-referenced facility violation timeline with county health department respiratory complaint data by ZIP code"
     }
   ],
@@ -29,13 +29,13 @@
   "review": [
     {
       "reviewer": "Sarah Kwan",
-      "type": "editorial-review",
+      "type": "editorial",
       "timestamp": "2026-03-15T14:00:00Z",
       "notes": "Editor reviewed all findings; made framing decision on health-data correlation; chose contextualized presentation over omission or unqualified inclusion"
     },
     {
       "reviewer": "Rachel Torres",
-      "type": "legal-review",
+      "type": "other",
       "timestamp": "2026-03-17T11:00:00Z",
       "notes": "Reviewed for defamation risk; requested softened characterization of DEQ enforcement and inclusion of full Meridian statement"
     },

--- a/examples/nonprofit-humanitarian.halos.json
+++ b/examples/nonprofit-humanitarian.halos.json
@@ -15,7 +15,7 @@
     {
       "model": "crisismap-analytics-v3",
       "provider": "CrisisMap AI",
-      "role": "analysis",
+      "role": "assistance",
       "description": "Analyzed satellite imagery, social media aggregation, and logistics data to produce ranked village priority list and recommended convoy routing"
     }
   ],

--- a/examples/realtime-critical-systems.halos.json
+++ b/examples/realtime-critical-systems.halos.json
@@ -15,7 +15,7 @@
     {
       "model": "processiq-optima-3.2",
       "provider": "ProcessIQ Industrial AI",
-      "role": "analysis",
+      "role": "assistance",
       "description": "Analyzed 18 months of SCADA historian data to identify flow/turbidity/temperature correlations and proposed a feedforward-feedback dosing algorithm with tuned parameters and seasonal adjustment curves"
     }
   ],

--- a/examples/scientific-research.halos.json
+++ b/examples/scientific-research.halos.json
@@ -15,7 +15,7 @@
     {
       "model": "claude-sonnet-4-6",
       "provider": "Anthropic",
-      "role": "analysis",
+      "role": "assistance",
       "taskType": "researching",
       "techniques": ["clustering", "partial-correlation-analysis"],
       "description": "Feature analysis on genomic sequencing data, partial correlation computation for confound investigation, and comparison of model features against published resistance mechanisms"


### PR DESCRIPTION
## Summary

- Replace all `"0.2-draft"` version strings with `"0.2"` across examples, schema, spec docs, and agent prompt
- Fix CI workflow to reference the correct schema filename (`halos-provenance-v0.2.schema.json`) and validate all domain `.halos.json` examples (previously only `v0.2-graph.json` was checked)
- Fix invalid field values in 6 domain examples that failed schema validation:
  - `ai_assistance[].role: "analysis"` → `"assistance"` (analysis is a graph interaction type, not a valid ai_assistance role)
  - `review[].type: "editorial-review"` → `"editorial"`, `"security-review"` / `"legal-review"` → `"other"`

## Test plan

- [ ] CI `validate` job passes on this PR
- [ ] All 9 v0.2 examples validate against `spec/schema/halos-provenance-v0.2.schema.json`
- [ ] No remaining `0.2-draft` strings in examples, schema, or spec docs

https://claude.ai/code/session_01GppNY5LbVL2dN8tJ2DXmdP